### PR TITLE
Allow 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         group:
           - All
         version:
+          - '1.9'
           - '1'
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "SymbolicIndexingInterface"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.3.3"
+version = "0.3.4"
 
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.0.1"
 Test = "1"
-julia = "1.10"
+julia = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
From git history, it seems like the bump to 1.10 was accidental (at least it was associated with a Aqua testing PR)

Can we allow 1.9 if the tests pass? Currently, this is a dep of SciMLBase, so it essentially means a lot of downstream packages will have to drop 1.9 to depend on the latest SciMLBase.

