### PR TITLE
fix: do not call current_time for time-independent systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ eqs = [D(D(x)) ~ σ * (y - x),
     D(z) ~ x * y - β * z,
     w ~ x + y + z]
 
-@named sys = ODESystem(eqs)
-sys = structural_simplify(sys)
+@mtkbuild sys = ODESystem(eqs)
 
 u0 = [D(x) => 2.0,
     x => 1.0,

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -32,8 +32,7 @@ eqs = [D(D(x)) ~ σ * (y - x),
     D(z) ~ x * y - β * z,
     w ~ x + y + z]
 
-@named sys = ODESystem(eqs)
-sys = structural_simplify(sys)
+@mtkbuild sys = ODESystem(eqs, t)
 ```
 
 The system has 4 state variables, 3 parameters, and one observed variable:


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
