### PR TITLE
docs: allow `symbolic_evaluate` to have arbitrary kwargs

### DIFF
--- a/src/trait.jl
+++ b/src/trait.jl
@@ -62,7 +62,7 @@ Get the name of a symbolic variable as a `Symbol`
 function getname end
 
 """
-    symbolic_evaluate(expr, syms::Dict)
+    symbolic_evaluate(expr, syms::Dict; kwargs...)
 
 Return the value of symbolic expression `expr` where the values of variables involved are
 obtained from the dictionary `syms`. The keys of `syms` are symbolic variables (not
@@ -71,6 +71,9 @@ expressions.
 
 The returned value should either be a value or an expression involving symbolic variables
 not present as keys in `syms`.
+
+The function can take additional keyword arguments to control implementation-specific
+behavior.
 
 This is already implemented for 
 `symbolic_evaluate(expr::Union{Symbol, Expr}, syms::Dict)`.


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
