### PR TITLE
fix: add dedicated code paths for non-scalarized array symbolics in getu/getp

### DIFF
--- a/src/parameter_indexing.jl
+++ b/src/parameter_indexing.jl
@@ -140,6 +140,11 @@ for (t1, t2) in [
 end
 
 function _getp(sys, ::ArraySymbolic, ::NotSymbolic, p)
+    if is_parameter(sys, p)
+        idx = parameter_index(sys, p)
+        return invoke(_getp, Tuple{Any, NotSymbolic, NotSymbolic, Any},
+            sys, NotSymbolic(), NotSymbolic(), idx)
+    end
     return getp(sys, collect(p))
 end
 
@@ -205,5 +210,9 @@ for (t1, t2) in [
 end
 
 function _setp(sys, ::ArraySymbolic, ::NotSymbolic, p)
+    if is_parameter(sys, p)
+        idx = parameter_index(sys, p)
+        return setp(sys, idx; run_hook = false)
+    end
     return setp(sys, collect(p); run_hook = false)
 end

--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -165,6 +165,12 @@ for (t1, t2) in [
 end
 
 function _getu(sys, ::ArraySymbolic, ::NotSymbolic, sym)
+    if is_variable(sys, sym)
+        idx = variable_index(sys, sym)
+        return getu(sys, idx)
+    elseif is_parameter(sys, sym)
+        return getp(sys, sym)
+    end
     return getu(sys, collect(sym))
 end
 
@@ -221,5 +227,11 @@ for (t1, t2) in [
 end
 
 function _setu(sys, ::ArraySymbolic, ::NotSymbolic, sym)
+    if is_variable(sys, sym)
+        idx = variable_index(sys, sym)
+        return setu(sys, idx)
+    elseif is_parameter(sys, sym)
+        return setp(sys, sym)
+    end
     return setu(sys, collect(sym))
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
