### PR TITLE
fix: change `default_values` implementation for backward compatibility

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -140,7 +140,13 @@ all_symbols(sys) = all_symbols(symbolic_container(sys))
 Return a dictionary mapping symbols in the system to their default value, if any. This
 includes parameter symbols. The dictionary must be mutable.
 """
-default_values(sys) = default_values(symbolic_container(sys))
+function default_values(sys)
+    if hasmethod(symbolic_container, Tuple{typeof(sys)})
+        default_values(symbolic_container(sys))
+    else
+        Dict()
+    end
+end
 
 struct SolvedVariables end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
