### PR TITLE
fix: make `remake_buffer` work for array symbolics

### DIFF
--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/test/downstream/remake_arrayvars.jl
+++ b/test/downstream/remake_arrayvars.jl
@@ -1,0 +1,11 @@
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t
+using SymbolicIndexingInterface
+
+@variables x(t)[1:2] y(t)
+@named sys = ODESystem(Equation[], t, [x, y], [])
+sys = complete(sys)
+
+u0 = [1.0, 2.0, 3.0]
+newu0 = remake_buffer(sys, u0, Dict(x => [5.0, 6.0], y => 7.0))
+@test newu0 == [5.0, 6.0, 7.0]


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
