### PR TITLE
don't collect observed `ArraySymbolics`

### DIFF
--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -175,6 +175,17 @@ function _getu(sys, ::ArraySymbolic, ::SymbolicTypeTrait, sym)
         return getu(sys, idx)
     elseif is_parameter(sys, sym)
         return getp(sys, sym)
+    elseif is_observed(sys, sym)
+        obs = observed(sys, sym isa Tuple ? collect(sym) : sym)
+        getter = if is_time_dependent(sys)
+            TimeDependentObservedFunction(obs)
+        else
+            TimeIndependentObservedFunction(obs)
+        end
+        if sym isa Tuple
+            getter = AsTupleWrapper(getter)
+        end
+        return getter
     end
     return getu(sys, collect(sym))
 end


### PR DESCRIPTION
If `is_observed` returns true for `ArraySymbolic`, forward directly to `observed` instead of collecting first.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
