### PR TITLE
fix: default to ContinuousTimeseries for symbol not in `SymbolCache`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicIndexingInterface"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.3.25"
+version = "0.3.26"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/symbol_cache.jl
+++ b/src/symbol_cache.jl
@@ -130,6 +130,14 @@ function timeseries_parameter_index(sc::SymbolCache, sym)
         return get(sc.timeseries_parameters, sym, nothing)
     end
 end
+
+for symT in [Any, Expr, AbstractArray]
+    @eval function get_all_timeseries_indexes(
+            ::SymbolCache{Nothing, Nothing, Nothing}, ::$symT)
+        Set([ContinuousTimeseries()])
+    end
+end
+
 function get_all_timeseries_indexes(sc::SymbolCache, sym)
     if is_variable(sc, sym) || is_independent_variable(sc, sym)
         return Set([ContinuousTimeseries()])

--- a/test/symbol_cache_test.jl
+++ b/test/symbol_cache_test.jl
@@ -123,3 +123,8 @@ sc2 = copy(sc)
 @test sc.variables == sc2.variables
 @test sc.parameters == sc2.parameters
 @test sc.independent_variables == sc2.independent_variables
+
+sc = SymbolCache()
+for sym in [1, :a, :(a + b), "foo", [:a, :b], [:(a + b), :c]]
+    @test only(get_all_timeseries_indexes(sc, sym)) == ContinuousTimeseries()
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
