### PR TITLE
fix: fix stack overflow for methods using `symbolic_container` to define a fallback

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,7 +5,6 @@
 ### Mandatory methods
 
 ```@docs
-symbolic_container
 is_variable
 variable_index
 variable_symbols
@@ -25,6 +24,10 @@ allvariables
 ```
 
 ### Optional Methods
+
+```@docs
+symbolic_container
+```
 
 #### Observed equation handling
 

--- a/src/index_provider_interface.jl
+++ b/src/index_provider_interface.jl
@@ -59,8 +59,8 @@ parameter_index(indp, sym) = parameter_index(symbolic_container(indp), sym)
 Check whether the given `sym` is a timeseries parameter in `indp`.
 """
 function is_timeseries_parameter(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)})
-        is_timeseries_parameter(symbolic_container(indp), sym)
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+        is_timeseries_parameter(sc, sym)
     else
         return false
     end
@@ -91,7 +91,7 @@ parameter in `indp`. Defaults to returning `nothing`. Respects the
 [`symbolic_container`](@ref) fallback for `indp` if present.
 """
 function timeseries_parameter_index(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)})
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
         timeseries_parameter_index(symbolic_container(indp), sym)
     else
         return nothing
@@ -111,7 +111,7 @@ By default, this function returns `nothing`, indicating that the index provider 
 support generating parameter observed functions.
 """
 function parameter_observed(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)})
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
         return parameter_observed(symbolic_container(indp), sym)
     else
         return nothing
@@ -143,7 +143,7 @@ variable.
 By default, this function returns `Set([ContinuousTimeseries()])`.
 """
 function get_all_timeseries_indexes(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)})
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
         return get_all_timeseries_indexes(symbolic_container(indp), sym)
     else
         return Set([ContinuousTimeseries()])
@@ -240,7 +240,7 @@ Return a dictionary mapping symbols in the index provider to their default value
 This includes parameter symbols. The dictionary must be mutable.
 """
 function default_values(indp)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)})
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
         default_values(symbolic_container(indp))
     else
         Dict()

--- a/src/index_provider_interface.jl
+++ b/src/index_provider_interface.jl
@@ -64,7 +64,8 @@ parameter_index(indp, sym) = parameter_index(symbolic_container(indp), sym)
 Check whether the given `sym` is a timeseries parameter in `indp`.
 """
 function is_timeseries_parameter(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
+       (sc = symbolic_container(indp)) != indp
         is_timeseries_parameter(sc, sym)
     else
         return false
@@ -96,7 +97,8 @@ parameter in `indp`. Defaults to returning `nothing`. Respects the
 [`symbolic_container`](@ref) fallback for `indp` if present.
 """
 function timeseries_parameter_index(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
+       (sc = symbolic_container(indp)) != indp
         timeseries_parameter_index(symbolic_container(indp), sym)
     else
         return nothing
@@ -116,7 +118,8 @@ By default, this function returns `nothing`, indicating that the index provider 
 support generating parameter observed functions.
 """
 function parameter_observed(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
+       (sc = symbolic_container(indp)) != indp
         return parameter_observed(symbolic_container(indp), sym)
     else
         return nothing
@@ -148,7 +151,8 @@ variable.
 By default, this function returns `Set([ContinuousTimeseries()])`.
 """
 function get_all_timeseries_indexes(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
+       (sc = symbolic_container(indp)) != indp
         return get_all_timeseries_indexes(symbolic_container(indp), sym)
     else
         return Set([ContinuousTimeseries()])
@@ -245,7 +249,8 @@ Return a dictionary mapping symbols in the index provider to their default value
 This includes parameter symbols. The dictionary must be mutable.
 """
 function default_values(indp)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
+       (sc = symbolic_container(indp)) != indp
         default_values(symbolic_container(indp))
     else
         Dict()

--- a/src/index_provider_interface.jl
+++ b/src/index_provider_interface.jl
@@ -5,6 +5,11 @@ Using `indp`, return an object that implements the index provider interface. In 
 itself implements the interface, `indp` can be returned as-is. All index provider interface
 methods fall back to calling the same method on `symbolic_container(indp)`, so this may be
 used for trivial implementations of the interface that forward all calls to another object.
+
+Note that this method is optional. Thus the correct method to check for a fallback is:
+```julia
+hasmethod(symbolic_container, Tuple{typeof(indp)}) && symbolic_container(indp) != indp
+```
 """
 function symbolic_container end
 

--- a/src/index_provider_interface.jl
+++ b/src/index_provider_interface.jl
@@ -59,7 +59,7 @@ parameter_index(indp, sym) = parameter_index(symbolic_container(indp), sym)
 Check whether the given `sym` is a timeseries parameter in `indp`.
 """
 function is_timeseries_parameter(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
         is_timeseries_parameter(sc, sym)
     else
         return false
@@ -91,7 +91,7 @@ parameter in `indp`. Defaults to returning `nothing`. Respects the
 [`symbolic_container`](@ref) fallback for `indp` if present.
 """
 function timeseries_parameter_index(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
         timeseries_parameter_index(symbolic_container(indp), sym)
     else
         return nothing
@@ -111,7 +111,7 @@ By default, this function returns `nothing`, indicating that the index provider 
 support generating parameter observed functions.
 """
 function parameter_observed(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
         return parameter_observed(symbolic_container(indp), sym)
     else
         return nothing
@@ -143,7 +143,7 @@ variable.
 By default, this function returns `Set([ContinuousTimeseries()])`.
 """
 function get_all_timeseries_indexes(indp, sym)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
         return get_all_timeseries_indexes(symbolic_container(indp), sym)
     else
         return Set([ContinuousTimeseries()])
@@ -240,7 +240,7 @@ Return a dictionary mapping symbols in the index provider to their default value
 This includes parameter symbols. The dictionary must be mutable.
 """
 function default_values(indp)
-    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) !== indp
+    if hasmethod(symbolic_container, Tuple{typeof(indp)}) && (sc = symbolic_container(indp)) != indp
         default_values(symbolic_container(indp))
     else
         Dict()

--- a/src/symbol_cache.jl
+++ b/src/symbol_cache.jl
@@ -71,8 +71,6 @@ function SymbolCache(vars = nothing, params = nothing, indepvars = nothing;
         defaults)
 end
 
-symbolic_container(sc::SymbolCache) = sc
-
 function is_variable(sc::SymbolCache, sym)
     sc.variables === nothing && return false
     if symbolic_type(sym) == NotSymbolic()

--- a/src/symbol_cache.jl
+++ b/src/symbol_cache.jl
@@ -71,6 +71,8 @@ function SymbolCache(vars = nothing, params = nothing, indepvars = nothing;
         defaults)
 end
 
+symbolic_container(sc::SymbolCache) = sc
+
 function is_variable(sc::SymbolCache, sym)
     sc.variables === nothing && return false
     if symbolic_type(sym) == NotSymbolic()


### PR DESCRIPTION
Close #85 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
