### PR TITLE
fix: remove erroneous getter returned from setp

### DIFF
--- a/src/parameter_indexing.jl
+++ b/src/parameter_indexing.jl
@@ -683,10 +683,6 @@ function _setp(sys, ::ArraySymbolic, ::SymbolicTypeTrait, p)
     if is_parameter(sys, p)
         idx = parameter_index(sys, p)
         return setp(sys, idx; run_hook = false)
-    elseif is_observed(sys, p) && (pobsfn = parameter_observed(sys, p)) !== nothing
-        ts_idxs = _postprocess_tsidxs(get_all_timeseries_indexes(sys, p))
-        update_fn = Fix1Multiple(parameter_values_at_time, sys)
-        return GetParameterObserved{false}(ts_idxs, update_fn, pobsfn.observed_fn)
     end
     return setp(sys, collect(p); run_hook = false)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
