### PR TITLE
fix: fix `remake_buffer` with a `Tuple` buffer and `Dict{Any, Any}` varmap

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -77,11 +77,13 @@ end
 
 function remake_buffer(sys, oldbuffer::Tuple, idxs, vals)
     wrap = TupleRemakeWrapper(oldbuffer)
-    setu(sys, idxs)(wrap, vals)
+    for (idx, val) in zip(idxs, vals)
+        setu(sys, idx)(wrap, val)
+    end
     return wrap.t
 end
 
 @deprecate remake_buffer(sys, oldbuffer, vals::Dict) remake_buffer(
     sys, oldbuffer, keys(vals), values(vals))
 @deprecate remake_buffer(sys, oldbuffer::Tuple, vals::Dict) remake_buffer(
-    sys, oldbuffer, collect(keys(vals)), collect(values(vals)))
+    sys, oldbuffer, keys(vals), values(vals))

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -23,6 +23,13 @@ for (buf, newbuf, idxs, vals) in [
     # skip non-parameters
     ([1, 2, 3], [2.0, 3.0, 3.0], [:a, :b, :(a + b)], [2.0, 3.0, 5.0])
 ]
+    @test_deprecated remake_buffer(sys, buf, Dict(idxs .=> vals))
+    for varmap in [Dict(idxs .=> vals), Dict{Any, Any}(idxs .=> vals)]
+        _newbuf = remake_buffer(sys, buf, keys(varmap), values(varmap))
+        @test _newbuf != buf
+        @test newbuf == _newbuf
+        @test typeof(newbuf) == typeof(_newbuf)
+    end
     for arrType in [Vector, SVector{3}, MVector{3}, SizedVector{3}]
         buf = arrType(buf)
         newbuf = arrType(newbuf)
@@ -31,7 +38,6 @@ for (buf, newbuf, idxs, vals) in [
         @test _newbuf != buf # should not alias
         @test newbuf == _newbuf # test values
         @test typeof(newbuf) == typeof(_newbuf) # ensure appropriate type
-        @test_deprecated remake_buffer(sys, buf, Dict(idxs .=> vals))
     end
 end
 
@@ -55,8 +61,13 @@ for (buf, newbuf, idxs, vals) in [
     # skip non-variables
     ([1, 2, 3], [2.0, 3.0, 3.0], [:x, :y, :(x + y)], [2.0, 3.0, 5.0])
 ]
+    @test_deprecated remake_buffer(sys, buf, Dict(idxs .=> vals))
+    for varmap in [Dict(idxs .=> vals), Dict{Any, Any}(idxs .=> vals)]
+        _newbuf = remake_buffer(sys, buf, keys(varmap), values(varmap))
+        @test newbuf == _newbuf
+        @test typeof(newbuf) == typeof(_newbuf)
+    end
     _newbuf = remake_buffer(sys, buf, idxs, vals)
     @test newbuf == _newbuf # test values
     @test typeof(newbuf) == typeof(_newbuf) # ensure appropriate type
-    @test_deprecated remake_buffer(sys, buf, Dict(idxs .=> vals))
 end


### PR DESCRIPTION


## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
