### PR TITLE
Fix possible `StackOverflowError`s for `remake_buffer` & `InitializationProblem`s

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -55,6 +55,8 @@ function remake_buffer(sys, oldbuffer::AbstractArray, idxs, vals)
     return newbuffer
 end
 
+remake_buffer(sys, ::Nothing, idxs, vals) = nothing
+
 function remake_buffer(sys, oldbuffer, idxs, vals)
     remake_buffer(sys, oldbuffer, Dict(idxs .=> vals))
 end

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -71,3 +71,5 @@ for (buf, newbuf, idxs, vals) in [
     @test newbuf == _newbuf # test values
     @test typeof(newbuf) == typeof(_newbuf) # ensure appropriate type
 end
+
+@test isnothing(remake_buffer(sys, nothing, [], []))


### PR DESCRIPTION
For `InitializationProblem`s `state_values(prob)` can return `nothing`,
so calls like

```julia
remake_buffer(prob, state_values(prob), keys(u0), values(u0))
```

would lead to `StackOverflowError`s due to the fallback for the deprecated `Dict` method.
```julia
function remake_buffer(sys, oldbuffer, idxs, vals)
    remake_buffer(sys, oldbuffer, Dict(idxs .=> vals))
end
```

This can crash julia if depwarns are enabled. The output would look like
```
julia> remake(prob1, u0=prob1.u0)
┌ Warning: `remake_buffer(sys, oldbuffer, vals::Dict)` is deprecated, use `remake_buffer(sys, oldbuffer, keys(vals), values(vals))` instead.
│   caller = remake_buffer(sys::NonlinearSystem, oldbuffer::Nothing, idxs::Vector{Int64}, vals::Vector{Any}) at remake.jl:59
└ @ SymbolicIndexingInterface ~/.julia/packages/SymbolicIndexingInterface/GKI0D/src/remake.jl:59
┌ Warning: `remake_buffer(sys, oldbuffer, vals::Dict)` is deprecated, use `remake_buffer(sys, oldbuffer, keys(vals), values(vals))` instead.
│   caller = remake_buffer(sys::NonlinearSystem, oldbuffer::Nothing, idxs::Base.KeySet{Any, Dict{Any, Any}}, vals::Base.ValueIterator{Dict{Any, Any}}) at remake.jl:59
└ @ SymbolicIndexingInterface ~/.julia/packages/SymbolicIndexingInterface/GKI0D/src/remake.jl:59

[2462463] signal 6 (-6): Aborted
in expression starting at none:0
Aborted (core dumped)
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I got the above by running
```julia
using ModelingToolkit, OrdinaryDiffEqTsit5
using SciMLBase

function experiment1_sys()
    D = ModelingToolkit.D_nounits
    t = ModelingToolkit.t_nounits
    @parameters p1 = 0.5 [tunable = true] (p23[1:2] = [1, 3.0]) [tunable = true] p4 = 3 * p1 [tunable = false] y0 = 1.2 [tunable = true]
    @variables x(t) = 2p1 y(t) = y0 z(t) = x + y

    eqs = [D(x) ~ p1 * x - p23[1] * x * y
        D(y) ~ -p23[2] * y + p4 * x * y
        z ~ x + y]

    structural_simplify(ODESystem(eqs, t, tspan=(0, 3.0), name=:sys))
end

sys1 = experiment1_sys()
prob1 = ODEProblem(sys1, [sys1.p23 => [2, 4.0]])

remake(prob1, u0=prob1.u0)
```
on julia 1.11.0 (I tested on Linux so far) with `--depwarn=yes --check-bounds=yes`

