### PR TITLE
Smc/vec

### DIFF
--- a/src/batched_interface.jl
+++ b/src/batched_interface.jl
@@ -331,7 +331,7 @@ function setsym_oop(bi::BatchedInterface)
             push!(curexpr.args, :($paramssym = $parameter_values($prob)))
         else
             param_idxssym = Symbol(:param_idxs_, sys_i)
-            param_idxs = indp_idxs[.!isstate]
+            param_idxs = (indp_idxs[.!isstate]...,)
             param_valssym = Symbol(:param_vals, sys_i)
             vals_idxs = union_idxs[.!isstate]
             push!(curexpr.args, :($param_idxssym = $param_idxs))

--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -464,6 +464,10 @@ for (t1, t2) in [
                 throw(NotVariableOrParameter("setsym_oop", s))
             end
         end
+        if sym isa Tuple
+            vars = Tuple(vars)
+            pars = Tuple(pars)
+        end
         indp = _root_indp(indp)
         return FullSetter(isempty(vars) ? nothing : OOPSetter(indp, identity.(vars), true),
             isempty(pars) ? nothing : OOPSetter(indp, identity.(pars), false),


### PR DESCRIPTION
The codegen for `setsym_oop::BatchedInterface` was making vectors of `ParameterIndex` instead of tuples

Doing
```julia
param_idxs = (indp_idxs[.!isstate]...,)
```
to turn it to a tuple seems to fix it, so we hit the new generated `_remake_buffer `