### PR TITLE
fix: fix stack overflow on `remake_buffer` of `Dict`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -55,6 +55,12 @@ function remake_buffer(sys, oldbuffer::AbstractArray, idxs, vals)
     return newbuffer
 end
 
+# We don't support `Dict`s as value providers. If we get a `Dict`,
+# assume it is non-symbolic.
+function remake_buffer(sys, oldbuffer::Dict, idxs, vals)
+    return Dict(idxs .=> vals)
+end
+
 remake_buffer(sys, ::Nothing, idxs, vals) = nothing
 
 function remake_buffer(sys, oldbuffer, idxs, vals)

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -73,3 +73,12 @@ for (buf, newbuf, idxs, vals) in [
 end
 
 @test isnothing(remake_buffer(sys, nothing, [], []))
+
+@testset "`remake_buffer` with `Dict`" begin
+    sys = nothing
+    buf = Dict("a" => 1, "b" => 2)
+    buf2 = remake_buffer(sys, buf, collect(keys(buf)), collect(values(buf)))
+    @test isequal(buf, buf2)
+    buf2 = remake_buffer(sys, buf, buf)
+    @test isequal(buf, buf2)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
