### PR TITLE
GetStateIndex: wrap idx so it broadcasts as scalar across timeseries

### DIFF
--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -41,7 +41,11 @@ function (gsi::GetStateIndex)(::Timeseries, prob, i::Union{Int, CartesianIndex})
     return getindex(state_values(prob, i), gsi.idx)
 end
 function (gsi::GetStateIndex)(::Timeseries, prob, i)
-    return getindex.(state_values(prob, i), gsi.idx)
+    # Wrap `gsi.idx` in a 1-tuple so it broadcasts as a scalar across the
+    # `state_values(prob, i)` collection. Without the wrap, an array-valued
+    # `gsi.idx` (e.g. `Vector{Int}` from an array-symbolic) is broadcast
+    # element-wise and errors with a shape mismatch against the time axis.
+    return getindex.(state_values(prob, i), (gsi.idx,))
 end
 function (gsi::GetStateIndex)(::NotTimeseries, prob)
     return state_values(prob, gsi.idx)

--- a/test/state_indexing_test.jl
+++ b/test/state_indexing_test.jl
@@ -375,6 +375,24 @@ let sol = sol, sys = sys
     @test getter(sol) == []
 end
 
+# A single `GetStateIndex` with a `Vector{Int}` idx — the shape downstream
+# packages construct when binding an array-valued symbolic (e.g. `x(t)[1:3]`)
+# to a single set of consecutive state indices. The non-`Int`/`CartesianIndex`
+# `i` overload must broadcast the idx vector as a scalar across the timeseries
+# rather than zipping it elementwise (otherwise a length-N timeseries against
+# a length-K idx vector errors with `DimensionMismatch`).
+let sol = sol
+    idx = [1, 2]
+    gsi = SymbolicIndexingInterface.GetStateIndex(idx)
+    expected = [u_t[idx] for u_t in sol.u]
+    @test gsi(Timeseries(), sol) == expected
+    @test gsi(Timeseries(), sol, :) == expected
+    @test gsi(Timeseries(), sol, 1:length(sol.u)) == expected
+    @test gsi(Timeseries(), sol, eachindex(sol.u)) == expected
+    @test gsi(Timeseries(), sol, trues(length(sol.u))) == expected
+    @test gsi(Timeseries(), sol, 2) == sol.u[2][idx]
+end
+
 sys = SymbolCache([:x, :y, :z], [:a, :b, :c])
 u = [1.0, 2.0, 3.0]
 p = [10.0, 20.0, 30.0]


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

`(gsi::GetStateIndex)(::Timeseries, prob, i)` (at \`src/state_indexing.jl:43\`) currently does:

\`\`\`julia
getindex.(state_values(prob, i), gsi.idx)
\`\`\`

This works when \`gsi.idx\` is a scalar Int (broadcasts as length-1 against the time axis), but errors when \`gsi.idx\` is array-valued — e.g. a \`Vector{Int}\` produced when the symbolic is array-typed like \`x(t)[1:3]\` — because the broadcast then tries to zip the length-N timeseries against the length-K index vector:

\`\`\`
DimensionMismatch: arrays could not be broadcast to a common size:
a has axes Base.OneTo(N) and b has axes Base.OneTo(K)
\`\`\`

The companion no-\`i\` overload (line 38) already handles this with a 1-tuple wrap:

\`\`\`julia
function (gsi::GetStateIndex)(::Timeseries, prob)
    return getindex.(state_values(prob), (gsi.idx,))  # wrapped
end
\`\`\`

This PR mirrors that wrap on the with-\`i\` overload so array-valued \`idx\` is always broadcast as a scalar across the time axis.

## Reproduction

Triggered by \`sol[x(t)[1:3], :]\` in the RecursiveArrayTools.jl downstream tests with MTK 11 + OrdinaryDiffEq 7. After fix, the call returns the expected \`Vector{Vector{Float64}}\` matching \`sol[x(t)[1:3]]\`.

## Side note

The same issue is being worked around on the RecursiveArrayTools.jl side in [SciML/RecursiveArrayTools.jl#594](https://github.com/SciML/RecursiveArrayTools.jl/pull/594) by short-circuiting \`A[sym, :] → A[sym]\` for symbolic indices; once this SII fix lands and gets released, that workaround can be removed.

## Test plan
- [x] Existing \`Pkg.test()\` passes locally (modulo the pre-existing \`jet_test.jl:161\` \`remake_buffer\` failure that's unrelated to this change and reproduces on master).
- [x] RAT downstream \`DiffEqArray Indexing Tests\` safetestset goes 357/358 → 358/358 when this fix is loaded.
- [ ] CI