### PR TITLE
Centralize CI on SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,16 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Downgrade
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,50 +7,19 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: RecursiveArrayTools.jl, group: SymbolicIndexingInterface}
           - {user: JuliaSymbolics, repo: Symbolics.jl, group: SymbolicIndexingInterface}
           - {user: SciML, repo: SciMLBase.jl, group: SymbolicIndexingInterface}
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "1"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,8 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic Format Check"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    with:
+      runic-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.2 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -119,7 +119,8 @@ using Test
 
         # Additional type optimization tests
         @test_opt target_modules = (SymbolicIndexingInterface,) is_independent_variable(
-            sc, :t)
+            sc, :t
+        )
         @test_opt target_modules = (SymbolicIndexingInterface,) independent_variable_symbols(sc)
         @test_opt target_modules = (SymbolicIndexingInterface,) all_variable_symbols(sc)
         @test_opt target_modules = (SymbolicIndexingInterface,) all_symbols(sc)
@@ -157,11 +158,13 @@ using Test
 
     @testset "remake_buffer static analysis" begin
         rep = JET.report_call(
-            remake_buffer, (typeof(sc), Vector{Float64}, Vector{Int}, Vector{Float64}))
+            remake_buffer, (typeof(sc), Vector{Float64}, Vector{Int}, Vector{Float64})
+        )
         @test length(JET.get_reports(rep)) == 0
 
         rep = JET.report_call(
-            remake_buffer, (typeof(sc), NTuple{3, Float64}, Vector{Int}, Vector{Float64}))
+            remake_buffer, (typeof(sc), NTuple{3, Float64}, Vector{Int}, Vector{Float64})
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the CI to use the centralized reusable workflows from `SciML/.github`, all pinned at `@v1` with `secrets: "inherit"`.

## Converted (inline -> central caller)
- **Downgrade** -> `downgrade.yml@v1` (preserved: julia-version `1.10`, group `Core`, `skip: Pkg,TOML`, `allow-reresolve: false`, `paths-ignore: docs/**`)
- **Downstream / IntegrationTest** -> matrix of `downstream.yml@v1` callers (preserved package+group list: RecursiveArrayTools.jl, Symbolics.jl, SciMLBase.jl, ModelingToolkit.jl — all group `SymbolicIndexingInterface`, julia `1`)
- **FormatCheck (Runic)** -> `runic.yml@v1` (runic-version `1`)
- **SpellCheck (typos)** -> `spellcheck.yml@v1`

## Already central (left as-is, confirmed `secrets: "inherit"`)
- **Tests** -> `tests.yml@v1` (matrix version × group preserved)
- **Documentation** -> `documentation.yml@v1`

## Cleanup
- `dependabot.yml`: removed the `crate-ci/typos` ignore block (typos is now centralized). `github-actions` (`/`, weekly) and `julia` (daily, `all-julia-packages` group) blocks preserved.
- No CompatHelper.yml present. TagBot.yml unchanged.

## Green-check work
- Runic v1.7 reformatted `test/jet_test.jl` (multi-arg call closing-paren wrapping). The previous inline Runic action at version `1` now resolves to 1.7, so this would already flag red on the current CI.
- `typos` reports clean (no fixes needed, 0 changes).

## Note on branch protection
Job/check names change with this conversion (e.g. the Downgrade/Downstream/Runic/SpellCheck jobs now render under the reusable-workflow job names). Required-status-check rules in branch protection will need updating to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)