### PR TITLE
Fix master CI: JET @test_broken Unexpected Pass and docs @ref cross-reference

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,7 +61,7 @@ sol = solve(prob, Tsit5())
 sol[x]
 ```
 
-For more detailed usage examples, see the [tutorials](@ref usage.md).
+For more detailed usage examples, see the [tutorials](usage.md).
 
 ## Contributing
 

--- a/test/qa/jet_test.jl
+++ b/test/qa/jet_test.jl
@@ -160,11 +160,7 @@ using Test
         rep = JET.report_call(
             remake_buffer, (typeof(sc), Vector{Float64}, Vector{Int}, Vector{Float64})
         )
-        # JET: remake_buffer(::SymbolCache, ::Vector{Float64}, ::Vector{Int}, ::Vector{Float64})
-        # allocates a Vector{Union{}} buffer (src/remake.jl:41), causing an invalid `typeassert`
-        # builtin call inside copyto!/_unsetindex! — tracked in
-        # https://github.com/SciML/SymbolicIndexingInterface.jl/issues/163
-        @test_broken length(JET.get_reports(rep)) == 0
+        @test length(JET.get_reports(rep)) == 0
 
         rep = JET.report_call(
             remake_buffer, (typeof(sc), NTuple{3, Float64}, Vector{Int}, Vector{Float64})


### PR DESCRIPTION
## Summary

Fixes the two real failures on `master` CI (ignoring unrelated downstream/dependabot noise):

### 1. QA jobs — `tests / QA (julia 1)` (1.12) and `tests / QA (julia lts)` (1.10)

`test/qa/jet_test.jl` — the `remake_buffer static analysis` `@test_broken` now **passes**, so `@test_broken` raises an `Unexpected Pass` error and fails the whole QA job:

```
remake_buffer static analysis: Error During Test at test/qa/jet_test.jl:167
 Unexpected Pass
 Got correct result, please change to @test if no longer broken.
ERROR: Some tests did not pass: 44 passed, 0 failed, 1 errored, 0 broken.
```

The JET finding tracked in #163 (`Vector{Union{}}` buffer typeassert inside `remake_buffer`) no longer reproduces on the current JET/Julia, so the assertion is flipped from `@test_broken` to `@test` (and the stale tracking comment removed). This is the action CI explicitly asks for. Issue #163 can be closed as resolved once this merges.

**Local verification (both CI channels):**
- Julia 1.12 (the `1` channel): reproduced the original `Unexpected Pass` with the old `@test_broken`; with the fix, `JET static analysis 45/45 pass`, exit 0.
- Julia 1.10 (`lts`): `JET static analysis 45/45 pass`, exit 0.

### 2. Documentation — `Documentation / Build and Deploy Documentation`

`docs/src/index.md` used `[tutorials](@ref usage.md)`. `@ref` resolves a doc symbol/heading binding, not a page filename, so `makedocs` terminated at the `:cross_references` stage:

```
Error: Cannot resolve @ref for md"[tutorials](@ref usage.md)" in docs/src/index.md.
- Exception trying to find docref for `usage.md`: unable to get the binding for `usage.md`
ERROR: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

Changed to the plain relative page link `[tutorials](usage.md)` — the correct way to link to another page (`usage.md` is a real page in `docs/pages.jl`).

**Local verification:** full `docs/make.jl` build on Julia 1.12 completes with exit 0, no `Cannot resolve @ref` / `:cross_references` error. (Only remaining output is the expected "could not auto-detect building environment, skipping deployment" notice and a pre-existing SVG-fallback size warning on `usage.md`, both unrelated.)

Runic check on `test/qa/jet_test.jl` passes (no diff).

---

Please ignore until reviewed by @ChrisRackauckas