### PR TITLE
Add ExplicitImports.jl QA via SciMLTesting run_qa

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,11 +20,12 @@ Accessors = "0.1.36"
 AllocCheck = "0.2"
 Aqua = "0.8"
 ArrayInterface = "7.9"
+ExplicitImports = "1.10"
 JET = "0.9, 0.10, 0.11"
 PrettyTables = "3"
 RuntimeGeneratedFunctions = "0.5.12"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.4"
 StaticArrays = "1.9"
 StaticArraysCore = "1.4"
 Test = "1"
@@ -34,6 +35,7 @@ julia = "1.10"
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -42,4 +44,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AllocCheck", "Aqua", "JET", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Zygote"]
+test = ["AllocCheck", "Aqua", "ExplicitImports", "JET", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,12 +20,11 @@ Accessors = "0.1.36"
 AllocCheck = "0.2"
 Aqua = "0.8"
 ArrayInterface = "7.9"
-ExplicitImports = "1.10"
 JET = "0.9, 0.10, 0.11"
 PrettyTables = "3"
 RuntimeGeneratedFunctions = "0.5.12"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.4"
+SciMLTesting = "1.5"
 StaticArrays = "1.9"
 StaticArraysCore = "1.4"
 Test = "1"
@@ -35,7 +34,6 @@ julia = "1.10"
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -44,4 +42,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AllocCheck", "Aqua", "ExplicitImports", "JET", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Zygote"]
+test = ["AllocCheck", "Aqua", "JET", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Zygote"]

--- a/src/SymbolicIndexingInterface.jl
+++ b/src/SymbolicIndexingInterface.jl
@@ -1,6 +1,6 @@
 module SymbolicIndexingInterface
 
-using RuntimeGeneratedFunctions
+using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFunction
 import StaticArraysCore: MArray, similar_type
 import ArrayInterface
 using Accessors: @reset

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,4 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -11,10 +9,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SymbolicIndexingInterface = {path = "../.."}
 
 [compat]
-Aqua = "0.8"
-ExplicitImports = "1.10"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.4"
+SciMLTesting = "1.5"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -11,8 +12,9 @@ SymbolicIndexingInterface = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
+ExplicitImports = "1.10"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,6 @@
 using SymbolicIndexingInterface
-using Aqua
-using ExplicitImports
 using SciMLTesting
+using Test
 
 # ExplicitImports per-check ignore-lists: each entry is a dependency name that is
 # genuinely required but is neither exported nor declared `public` by its owner
@@ -16,8 +15,6 @@ using SciMLTesting
 #                      array types (`MArray`, …), not `similar_type`.
 run_qa(
     SymbolicIndexingInterface;
-    Aqua = Aqua,
-    ExplicitImports = ExplicitImports,
     explicit_imports = true,
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = (:init, :ismutable, :Fix1)),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,11 +1,26 @@
-using SymbolicIndexingInterface, Aqua
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(SymbolicIndexingInterface)
-    Aqua.test_ambiguities(SymbolicIndexingInterface, recursive = false)
-    Aqua.test_deps_compat(SymbolicIndexingInterface)
-    Aqua.test_piracies(SymbolicIndexingInterface)
-    Aqua.test_project_extras(SymbolicIndexingInterface)
-    Aqua.test_stale_deps(SymbolicIndexingInterface)
-    Aqua.test_unbound_args(SymbolicIndexingInterface)
-    Aqua.test_undefined_exports(SymbolicIndexingInterface)
-end
+using SymbolicIndexingInterface
+using Aqua
+using ExplicitImports
+using SciMLTesting
+
+# ExplicitImports per-check ignore-lists: each entry is a dependency name that is
+# genuinely required but is neither exported nor declared `public` by its owner
+# package, and has no public alternative to switch to.
+#   * `init`         — RuntimeGeneratedFunctions.init(@__MODULE__): mandatory RGF setup
+#                      boilerplate; RGF exposes no public spelling of it.
+#   * `ismutable`    — ArrayInterface.ismutable: ArrayInterface exports/declares no
+#                      public names at all, so every access is necessarily non-public.
+#   * `Fix1`         — Base.Fix1: public in recent Julia but not on the v1.10 LTS, where
+#                      ExplicitImports flags it; used for partial application.
+#   * `similar_type` — StaticArraysCore.similar_type: StaticArraysCore exports only the
+#                      array types (`MArray`, …), not `similar_type`.
+run_qa(
+    SymbolicIndexingInterface;
+    Aqua = Aqua,
+    ExplicitImports = ExplicitImports,
+    explicit_imports = true,
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (; ignore = (:init, :ismutable, :Fix1)),
+        all_explicit_imports_are_public = (; ignore = (:similar_type,)),
+    ),
+)


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Wires ExplicitImports.jl into the QA group through `SciMLTesting.run_qa`, running all **six** checks alongside the existing Aqua and JET checks:

- Standard: `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`
- Public-API: `all_qualified_accesses_are_public`, `all_explicit_imports_are_public`

## Resolution of every flagged name (FIX > DECLARE-PUBLIC > minimal-IGNORE)

**FIX (implicit → explicit).** `using RuntimeGeneratedFunctions` → `using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFunction`. This resolves `check_no_implicit_imports` (the only fixable violation).

**DECLARE-PUBLIC.** None required: every intended-public `SymbolicIndexingInterface` name is already `export`ed, so none of the checks flag this package's own surface.

**Minimal documented IGNORE** (4 names, each a genuinely-required dependency internal with no public alternative; the checks themselves are *not* disabled — only these specific names are exempted, and each is documented in `test/qa/qa.jl`):

| Name | Owner | Check | Why unavoidable |
|------|-------|-------|-----------------|
| `init` | RuntimeGeneratedFunctions | `all_qualified_accesses_are_public` | `RuntimeGeneratedFunctions.init(@__MODULE__)` is mandatory RGF setup; RGF exposes no public spelling |
| `ismutable` | ArrayInterface | `all_qualified_accesses_are_public` | ArrayInterface exports/declares **no** public names; every access is necessarily non-public |
| `Fix1` | Base | `all_qualified_accesses_are_public` | `Base.Fix1` is public in recent Julia but not on the v1.10 LTS, where ExplicitImports flags it |
| `similar_type` | StaticArraysCore | `all_explicit_imports_are_public` | StaticArraysCore exports only the array types (`MArray`, …), not `similar_type` |

## Test deps

- Add `ExplicitImports` to `[extras]`, `[targets].test`, and `[compat]` (`"1.10"`) in both `Project.toml` and `test/qa/Project.toml`.
- Bump `SciMLTesting` `[compat]` to `"1.4"` (the version whose `run_qa` supports ExplicitImports).

JET (`test/qa/jet_test.jl`) is preserved unchanged. The QA-group Aqua body now goes through `run_qa`'s `Aqua.test_all` (the SciML standard), which is stricter than the previous hand-rolled selective checks.

## Verification (run locally)

```
GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'   # lts
  QA/jet_test.jl |   45     45
  QA/qa.jl       |   17     17
  Testing SymbolicIndexingInterface tests passed

GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'   # "1"
  QA/jet_test.jl |   45     45
  QA/qa.jl       |   17     17
  Testing SymbolicIndexingInterface tests passed
```

All six ExplicitImports checks were also confirmed individually passing on Julia 1.10, 1.11, and 1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)