### PR TITLE
Bump version to 0.3.50

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicIndexingInterface"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.49"
+version = "0.3.50"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.3.49 -> 0.3.50) to release unreleased commits on `master` via JuliaRegistrator.