### PR TITLE
Release prep: bump SymbolicIndexingInterface to 0.3.51

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicIndexingInterface"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.50"
+version = "0.3.51"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 0.3.50 (no functional/runtime changes).