### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -6,6 +7,7 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "2.1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -16,8 +16,10 @@ using Test
 run_qa(
     SymbolicIndexingInterface;
     explicit_imports = true,
+    api_docs = true,
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = (:init, :ismutable, :Fix1)),
         all_explicit_imports_are_public = (; ignore = (:similar_type,)),
     ),
+    api_docs_kwargs = (; rendered = true),
 )


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting API documentation QA with `api_docs_kwargs = (; rendered = true)`.
- Add Aqua as a direct dependency of the QA test environment so Aqua's ambiguity subprocess can load it under `test/qa`.

## Audit
- Checked current `origin/master` exports/public declarations. No package-owned exported names were missing source docstrings.
- No dependency-owned reexports were identified, so no `rendered_ignore` entries were added.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa test/qa/qa.jl`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Runic; exit(Runic.main(["--check", "test/qa/qa.jl"]))'`
- `git diff --check`
- Direct source docstring audit checked 61 exported package names with no missing source docstrings.