### PR TITLE
QA: scan the PrettyTables extension with ExplicitImports

### DIFF
--- a/ext/SymbolicIndexingInterfacePrettyTablesExt/SymbolicIndexingInterfacePrettyTablesExt.jl
+++ b/ext/SymbolicIndexingInterfacePrettyTablesExt/SymbolicIndexingInterfacePrettyTablesExt.jl
@@ -3,7 +3,7 @@ module SymbolicIndexingInterfacePrettyTablesExt
 using SymbolicIndexingInterface
 using SymbolicIndexingInterface: ParameterIndexingProxy, parameter_symbols, symbolic_type,
     ArraySymbolic, getp
-using PrettyTables
+using PrettyTables: PrettyTables, pretty_table
 
 # Override the fallback implementation with the PrettyTables version
 function SymbolicIndexingInterface.show_params(

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
@@ -9,6 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
+PrettyTables = "3"
 SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "2.1"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,10 @@ using SymbolicIndexingInterface
 using SciMLTesting
 using Test
 
+# ExplicitImports only sees an extension module once its trigger package is loaded, so
+# load every weakdep here to bring the extensions into the QA scan.
+using PrettyTables
+
 # ExplicitImports per-check ignore-lists: each entry is a dependency name that is
 # genuinely required but is neither exported nor declared `public` by its owner
 # package, and has no public alternative to switch to.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,6 +6,12 @@ using Test
 # load every weakdep here to bring the extensions into the QA scan.
 using PrettyTables
 
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(SymbolicIndexingInterface, :SymbolicIndexingInterfacePrettyTablesExt) !== nothing
+end
+
 # ExplicitImports per-check ignore-lists: each entry is a dependency name that is
 # genuinely required but is neither exported nor declared `public` by its owner
 # package, and has no public alternative to switch to.


### PR DESCRIPTION
## Why

`SciMLTesting.run_qa` runs ExplicitImports on the package module. ExplicitImports *does*
know about extensions — it reads the `[extensions]` table from `Project.toml` — but it
skips any extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep has been loaded. The QA
environment loaded no weakdeps, so `SymbolicIndexingInterfacePrettyTablesExt` was
never checked by QA.

## What this does

* Adds `PrettyTables` to `test/qa/Project.toml` (`[deps]` with the same UUID as the root
  `[weakdeps]` entry, plus a `[compat] PrettyTables = "3"` mirroring the root bound).
* Adds `using PrettyTables` to `test/qa/qa.jl` before `run_qa`, with a comment explaining
  that extensions are only visible to ExplicitImports once loaded.
* Adds a load guard asserting the extension module actually exists (see below).

## Load guard

Note that the skip quoted above is **silent**: if an extension ever fails to load or
precompile, `Base.get_extension` returns `nothing`, ExplicitImports quietly checks
nothing, and `run_qa` still reports a clean pass. QA would stay green while extension
coverage silently fell back to zero. To make that a hard failure instead, `qa.jl` now
asserts the extension module exists before `run_qa`:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(SymbolicIndexingInterface, :SymbolicIndexingInterfacePrettyTablesExt) !== nothing
end
```

## Coverage

* **Now scanned**: `SymbolicIndexingInterfacePrettyTablesExt`.
* **Still unscanned**: none — `PrettyTables` is the package's only weakdep, so extension
  coverage is complete.

## Findings and how they were resolved

Turning the scan on produced exactly one finding, and it was **fixed at the source, not
ignored**:

```
Module `SymbolicIndexingInterfacePrettyTablesExt` is relying on the following implicit imports:
* `PrettyTables` which is exported by `PrettyTables`
* `pretty_table` which is exported by `PrettyTables`
```

Fixed by changing `using PrettyTables` to `using PrettyTables: PrettyTables, pretty_table`
in the extension. Both names are exported by PrettyTables, so no ignore entry is needed.

**No new `ei_kwargs` ignore entries were added by this PR**, and no check was disabled or
marked broken.

## Local verification

Ran `GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch (Julia 1.12):

```
Test Summary:  | Pass  Total   Time
QA/jet_test.jl |   45     45  10.5s
Test Summary: | Pass  Total     Time
QA/qa.jl      |   22     22  1m29.3s
     Testing SymbolicIndexingInterface tests passed
```

`QA/qa.jl` goes 20 → 22 passing relative to master: +1 for the newly-scanned extension
clearing `no_implicit_imports`, +1 for the new load guard.

Before the extension source fix (i.e. with the scan enabled but the old `using PrettyTables`),
the same run failed with `20 passed, 0 failed, 1 errored` — the `no_implicit_imports`
error quoted above — which confirms the extension really is being scanned now.

`test/qa/Manifest.toml` is a local build artifact and is not committed.

---

Please ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
