### PR TITLE
Group abstractly-typed index vectors by concrete type in OOP setters

### DIFF
--- a/src/batched_interface.jl
+++ b/src/batched_interface.jl
@@ -336,7 +336,7 @@ function setsym_oop(bi::BatchedInterface)
             # group, since implementations that promote buffer eltypes from
             # `eltype(idxs)` require concrete index collections
             push!(curexpr.args, :($outsym = $buffer_expr))
-            for (gidxs, positions) in TypeGroupedIndexes(idxs).groups
+            for (gidxs, positions, _) in TypeGroupedIndexes(idxs).groups
                 push!(
                     curexpr.args,
                     :(

--- a/src/batched_interface.jl
+++ b/src/batched_interface.jl
@@ -316,6 +316,41 @@ function setsym_oop(bi::BatchedInterface)
     arg = :vals
     full_update = Expr(:block)
 
+    function push_remake_expr!(curexpr, outsym, sys_i, buffer_expr, idxs, vals_idxs, prefix)
+        idxs = identity.(idxs)
+        if isconcretetype(eltype(idxs))
+            idxssym = Symbol(prefix, :_idxs_, sys_i)
+            valssym = Symbol(prefix, :_vals_, sys_i)
+            push!(curexpr.args, :($idxssym = $idxs))
+            push!(curexpr.args, :($valssym = $view($arg, $vals_idxs)))
+            push!(
+                curexpr.args,
+                :(
+                    $outsym = $remake_buffer(
+                        syss[$sys_i], $buffer_expr, $idxssym, $valssym
+                    )
+                )
+            )
+        else
+            # mixed index types: apply `remake_buffer` once per concretely typed
+            # group, since implementations that promote buffer eltypes from
+            # `eltype(idxs)` require concrete index collections
+            push!(curexpr.args, :($outsym = $buffer_expr))
+            for (gidxs, positions) in TypeGroupedIndexes(idxs).groups
+                push!(
+                    curexpr.args,
+                    :(
+                        $outsym = $remake_buffer(
+                            syss[$sys_i], $outsym, $gidxs,
+                            $view($arg, $(vals_idxs[positions]))
+                        )
+                    )
+                )
+            end
+        end
+        return nothing
+    end
+
     function get_update_expr(prob::Symbol, sys_i::Int)
         union_idxs = bi.system_to_symbol_subset[sys_i]
         indp_idxs = bi.system_to_symbol_indexes[sys_i]
@@ -327,19 +362,9 @@ function setsym_oop(bi::BatchedInterface)
         if all(.!isstate)
             push!(curexpr.args, :($statessym = $state_values($prob)))
         else
-            state_idxssym = Symbol(:state_idxs_, sys_i)
-            state_idxs = indp_idxs[isstate]
-            state_valssym = Symbol(:state_vals_, sys_i)
-            vals_idxs = union_idxs[isstate]
-            push!(curexpr.args, :($state_idxssym = $state_idxs))
-            push!(curexpr.args, :($state_valssym = $view($arg, $vals_idxs)))
-            push!(
-                curexpr.args,
-                :(
-                    $statessym = $remake_buffer(
-                        syss[$sys_i], $state_values($prob), $state_idxssym, $state_valssym
-                    )
-                )
+            push_remake_expr!(
+                curexpr, statessym, sys_i, :($state_values($prob)),
+                indp_idxs[isstate], union_idxs[isstate], :state
             )
         end
 
@@ -347,19 +372,9 @@ function setsym_oop(bi::BatchedInterface)
         if all(isstate)
             push!(curexpr.args, :($paramssym = $parameter_values($prob)))
         else
-            param_idxssym = Symbol(:param_idxs_, sys_i)
-            param_idxs = indp_idxs[.!isstate]
-            param_valssym = Symbol(:param_vals, sys_i)
-            vals_idxs = union_idxs[.!isstate]
-            push!(curexpr.args, :($param_idxssym = $param_idxs))
-            push!(curexpr.args, :($param_valssym = $view($arg, $vals_idxs)))
-            push!(
-                curexpr.args,
-                :(
-                    $paramssym = $remake_buffer(
-                        syss[$sys_i], $parameter_values($prob), $param_idxssym, $param_valssym
-                    )
-                )
+            push_remake_expr!(
+                curexpr, paramssym, sys_i, :($parameter_values($prob)),
+                indp_idxs[.!isstate], union_idxs[.!isstate], :param
             )
         end
 

--- a/src/value_provider_interface.jl
+++ b/src/value_provider_interface.jl
@@ -283,7 +283,7 @@ function OOPSetter(indp, idxs, isstate)
 end
 
 _subset_values(val::AbstractArray, positions) = val[positions]
-_subset_values(val::Tuple, positions) = map(Base.Fix1(getindex, val), Tuple(positions))
+_subset_values(val::Tuple, positions) = ntuple(Base.Fix1(getindex, val) ∘ Base.Fix1(getindex, positions), Val(length(val)))
 
 _remake_buffer_grouped(indp, buffer, ::Tuple{}, val) = buffer
 function _remake_buffer_grouped(indp, buffer, groups::Tuple, val)

--- a/src/value_provider_interface.jl
+++ b/src/value_provider_interface.jl
@@ -243,7 +243,54 @@ struct OOPSetter{S, I, D}
     idxs::D
 end
 
-OOPSetter(indp, idxs, isstate) = OOPSetter{isstate, typeof(indp), typeof(idxs)}(indp, idxs)
+"""
+    TypeGroupedIndexes(idxs::AbstractVector)
+
+Indexes from an abstractly-typed vector partitioned into concretely typed
+groups, preserving first-occurrence order. Each group is a tuple of the
+concretely typed index vector and the positions of its entries in the
+original collection. `remake_buffer` implementations that compute buffer
+eltype promotion from `eltype(idxs)` (e.g. for `MTKParameters`) require
+concretely typed index collections; applying `remake_buffer` once per group
+satisfies that without splatting the indexes into a `Tuple`, whose length
+would scale codegen with the number of indexes.
+"""
+struct TypeGroupedIndexes{G <: Tuple}
+    groups::G
+end
+
+function TypeGroupedIndexes(idxs::AbstractVector)
+    group_idxs = []
+    group_positions = Vector{Int}[]
+    for (i, idx) in enumerate(idxs)
+        gi = findfirst(g -> typeof(first(g)) == typeof(idx), group_idxs)
+        if gi === nothing
+            push!(group_idxs, [idx])
+            push!(group_positions, [i])
+        else
+            push!(group_idxs[gi], idx)
+            push!(group_positions[gi], i)
+        end
+    end
+    return TypeGroupedIndexes(Tuple(map(tuple, group_idxs, group_positions)))
+end
+
+function OOPSetter(indp, idxs, isstate)
+    if idxs isa AbstractVector && !isconcretetype(eltype(idxs)) && !isempty(idxs)
+        idxs = TypeGroupedIndexes(idxs)
+    end
+    return OOPSetter{isstate, typeof(indp), typeof(idxs)}(indp, idxs)
+end
+
+_subset_values(val::AbstractArray, positions) = val[positions]
+_subset_values(val::Tuple, positions) = map(Base.Fix1(getindex, val), Tuple(positions))
+
+_remake_buffer_grouped(indp, buffer, ::Tuple{}, val) = buffer
+function _remake_buffer_grouped(indp, buffer, groups::Tuple, val)
+    idxs, positions = first(groups)
+    buffer = remake_buffer(indp, buffer, idxs, _subset_values(val, positions))
+    return _remake_buffer_grouped(indp, buffer, Base.tail(groups), val)
+end
 
 function (os::OOPSetter{true})(valp, val)
     buffer = hasmethod(state_values, Tuple{typeof(valp)}) ? state_values(valp) : valp
@@ -273,6 +320,21 @@ function (os::OOPSetter{false})(valp, val::Union{Tuple, AbstractArray})
     else
         return remake_buffer(os.indp, buffer, (os.idxs,), (val,))
     end
+end
+
+function (os::OOPSetter{true, I, <:TypeGroupedIndexes})(
+        valp, val::Union{Tuple, AbstractArray}
+    ) where {I}
+    buffer = hasmethod(state_values, Tuple{typeof(valp)}) ? state_values(valp) : valp
+    return _remake_buffer_grouped(os.indp, buffer, os.idxs.groups, val)
+end
+
+function (os::OOPSetter{false, I, <:TypeGroupedIndexes})(
+        valp, val::Union{Tuple, AbstractArray}
+    ) where {I}
+    buffer = hasmethod(parameter_values, Tuple{typeof(valp)}) ? parameter_values(valp) :
+        valp
+    return _remake_buffer_grouped(os.indp, buffer, os.idxs.groups, val)
 end
 
 function _root_indp(indp)

--- a/src/value_provider_interface.jl
+++ b/src/value_provider_interface.jl
@@ -248,15 +248,23 @@ end
 
 Indexes from an abstractly-typed vector partitioned into concretely typed
 groups, preserving first-occurrence order. Each group is a tuple of the
-concretely typed index vector and the positions of its entries in the
-original collection. `remake_buffer` implementations that compute buffer
-eltype promotion from `eltype(idxs)` (e.g. for `MTKParameters`) require
-concretely typed index collections; applying `remake_buffer` once per group
-satisfies that without splatting the indexes into a `Tuple`, whose length
-would scale codegen with the number of indexes.
+concretely typed index vector, the positions of its entries in the original
+collection, and the same positions encoded as a `Val` so `Tuple`s of values
+can be subset type-stably. `remake_buffer` implementations that compute
+buffer eltype promotion from `eltype(idxs)` (e.g. for `MTKParameters`)
+require concretely typed index collections; applying `remake_buffer` once
+per group satisfies that without splatting the indexes into a `Tuple`, whose
+length would scale codegen with the number of indexes.
 """
 struct TypeGroupedIndexes{G <: Tuple}
     groups::G
+end
+
+# Contiguous position runs are stored as a `UnitRange` so their `Val`-encoded
+# form does not scale the setter's type size with the number of indexes.
+function _compact_positions(positions::Vector{Int})
+    r = first(positions):last(positions)
+    return positions == r ? r : positions
 end
 
 function TypeGroupedIndexes(idxs::AbstractVector)
@@ -272,7 +280,11 @@ function TypeGroupedIndexes(idxs::AbstractVector)
             push!(group_positions[gi], i)
         end
     end
-    return TypeGroupedIndexes(Tuple(map(tuple, group_idxs, group_positions)))
+    groups = map(group_idxs, group_positions) do gidxs, positions
+        positions = _compact_positions(positions)
+        (gidxs, positions, Val(positions isa UnitRange ? positions : Tuple(positions)))
+    end
+    return TypeGroupedIndexes(Tuple(groups))
 end
 
 function OOPSetter(indp, idxs, isstate)
@@ -282,13 +294,18 @@ function OOPSetter(indp, idxs, isstate)
     return OOPSetter{isstate, typeof(indp), typeof(idxs)}(indp, idxs)
 end
 
-_subset_values(val::AbstractArray, positions) = val[positions]
-_subset_values(val::Tuple, positions) = ntuple(Base.Fix1(getindex, val) ∘ Base.Fix1(getindex, positions), Val(length(val)))
+_subset_values(val::AbstractArray, positions, _) = val[positions]
+# subsetting a (possibly heterogeneous) `Tuple` of values is only inferrable
+# with the positions available as compile-time constants, hence the `Val`
+function _subset_values(val::Tuple, positions, ::Val{P}) where {P}
+    return ntuple(i -> val[P[i]], Val(length(P)))
+end
 
 _remake_buffer_grouped(indp, buffer, ::Tuple{}, val) = buffer
 function _remake_buffer_grouped(indp, buffer, groups::Tuple, val)
-    idxs, positions = first(groups)
-    buffer = remake_buffer(indp, buffer, idxs, _subset_values(val, positions))
+    idxs, positions, static_positions = first(groups)
+    vals = _subset_values(val, positions, static_positions)
+    buffer = remake_buffer(indp, buffer, idxs, vals)
     return _remake_buffer_grouped(indp, buffer, Base.tail(groups), val)
 end
 

--- a/test/type_grouped_indexes_test.jl
+++ b/test/type_grouped_indexes_test.jl
@@ -1,5 +1,5 @@
 using SymbolicIndexingInterface
-using SymbolicIndexingInterface: TypeGroupedIndexes, OOPSetter
+using SymbolicIndexingInterface: TypeGroupedIndexes, OOPSetter, _subset_values
 using Test
 
 # Two distinct index types, mimicking providers whose parameter indexes carry
@@ -17,13 +17,32 @@ end
 @testset "TypeGroupedIndexes partitioning" begin
     tgi = TypeGroupedIndexes(Any[IndexKindA(1), IndexKindB(1), IndexKindA(2)])
     @test length(tgi.groups) == 2
-    (g1, p1), (g2, p2) = tgi.groups
+    (g1, p1, v1), (g2, p2, v2) = tgi.groups
     @test g1 isa Vector{IndexKindA}
     @test g1 == [IndexKindA(1), IndexKindA(2)]
     @test p1 == [1, 3]
+    @test v1 === Val((1, 3))
     @test g2 isa Vector{IndexKindB}
     @test g2 == [IndexKindB(1)]
-    @test p2 == [2]
+    # contiguous position runs compact to ranges so the `Val`-encoded form
+    # stays O(1) in the number of indexes
+    @test p2 == 2:2
+    @test v2 === Val(2:2)
+
+    tgi = TypeGroupedIndexes(Any[IndexKindA(1), IndexKindA(2), IndexKindB(1)])
+    (_, p1, v1), (_, p2, v2) = tgi.groups
+    @test p1 == 1:2
+    @test v1 === Val(1:2)
+    @test p2 == 3:3
+    @test v2 === Val(3:3)
+end
+
+@testset "_subset_values on tuples is exact" begin
+    val = (1.0f0, [2.0, 3.0], :sym)
+    @test @inferred(_subset_values(val, [1, 3], Val((1, 3)))) === (1.0f0, :sym)
+    @test @inferred(_subset_values(val, 2:3, Val(2:3))) == ([2.0, 3.0], :sym)
+    @test @inferred(_subset_values(val, 2:2, Val(2:2))) == ([2.0, 3.0],)
+    @test @inferred(_subset_values([1.0, 2.0, 3.0], [1, 3], Val((1, 3)))) == [1.0, 3.0]
 end
 
 struct TwoKindSys end
@@ -31,7 +50,7 @@ SymbolicIndexingInterface.is_variable(::TwoKindSys, sym) = false
 SymbolicIndexingInterface.variable_index(::TwoKindSys, sym) = nothing
 SymbolicIndexingInterface.is_parameter(::TwoKindSys, sym) = sym in (:a, :b, :c)
 function SymbolicIndexingInterface.parameter_index(::TwoKindSys, sym)
-    if sym === :a
+    return if sym === :a
         IndexKindA(1)
     elseif sym === :b
         IndexKindB(1)
@@ -56,7 +75,8 @@ SymbolicIndexingInterface.state_values(prob::TwoKindProb) = prob.u0
 SymbolicIndexingInterface.parameter_values(prob::TwoKindProb) = prob.p
 
 function SymbolicIndexingInterface.remake_buffer(
-        ::TwoKindSys, oldbuf::TwoKindParams, idxs, vals)
+        ::TwoKindSys, oldbuf::TwoKindParams, idxs, vals
+    )
     # the contract under test: implementations must never receive an
     # abstractly typed index collection
     @test isconcretetype(eltype(idxs))
@@ -89,6 +109,12 @@ end
     @test newps2.b === 2
     @test newps2.c === 3
 
+    # heterogeneous `Tuple` values subset correctly across groups
+    newps3 = set_mixed(prob, (1.5f0, [2.5], :sym))
+    @test newps3.a === 1.5f0
+    @test newps3.b == [2.5]
+    @test newps3.c === :sym
+
     # homogeneous index types stay a plain concrete vector
     set_homog = setp_oop(sys, [:b, :c])
     @test set_homog.idxs isa Vector{IndexKindB}
@@ -105,6 +131,46 @@ end
     _, newps = setter(prob, [1.5, 2.5])
     @test newps.a == 1.5
     @test newps.b == 2.5
+end
+
+# A provider whose `remake_buffer` is type-stable per concrete index vector,
+# to check the grouped setter chain infers exactly (mirrors the
+# "Type-stability of `remake_buffer`" downstream ModelingToolkit test, where
+# values are a heterogeneous `Tuple` such as `(Float16(1), Dual[...])`).
+struct StableTwoKindSys end
+SymbolicIndexingInterface.is_variable(::StableTwoKindSys, sym) = false
+SymbolicIndexingInterface.variable_index(::StableTwoKindSys, sym) = nothing
+SymbolicIndexingInterface.is_parameter(::StableTwoKindSys, sym) = sym in (:x, :y)
+function SymbolicIndexingInterface.parameter_index(::StableTwoKindSys, sym)
+    return sym === :x ? IndexKindA(1) : sym === :y ? IndexKindB(1) : nothing
+end
+
+struct PairParams{X, Y}
+    x::X
+    y::Y
+end
+
+function SymbolicIndexingInterface.remake_buffer(
+        ::StableTwoKindSys, oldbuf::PairParams, idxs::Vector{IndexKindA}, vals
+    )
+    return PairParams(vals[end], oldbuf.y)
+end
+function SymbolicIndexingInterface.remake_buffer(
+        ::StableTwoKindSys, oldbuf::PairParams, idxs::Vector{IndexKindB}, vals
+    )
+    return PairParams(oldbuf.x, vals[end])
+end
+
+@testset "grouped setp_oop infers exactly for heterogeneous Tuple values" begin
+    sys = StableTwoKindSys()
+    ps = PairParams(0.0, [0.0])
+
+    setter = setp_oop(sys, [:x, :y])
+    @test setter.idxs isa TypeGroupedIndexes
+    newps = @inferred setter(ps, (1.5f0, [2.5, 3.5]))
+    @test newps isa PairParams{Float32, Vector{Float64}}
+    @test newps.x === 1.5f0
+    @test newps.y == [2.5, 3.5]
 end
 
 @testset "BatchedInterface setsym_oop groups mixed index types" begin

--- a/test/type_grouped_indexes_test.jl
+++ b/test/type_grouped_indexes_test.jl
@@ -1,0 +1,122 @@
+using SymbolicIndexingInterface
+using SymbolicIndexingInterface: TypeGroupedIndexes, OOPSetter
+using Test
+
+# Two distinct index types, mimicking providers whose parameter indexes carry
+# the storage location in their type (e.g. the portions of
+# `ModelingToolkit.MTKParameters`). Such providers compute buffer eltype
+# promotion in `remake_buffer` from `eltype(idxs)`, which requires the OOP
+# setters to pass concretely typed index collections.
+struct IndexKindA
+    i::Int
+end
+struct IndexKindB
+    i::Int
+end
+
+@testset "TypeGroupedIndexes partitioning" begin
+    tgi = TypeGroupedIndexes(Any[IndexKindA(1), IndexKindB(1), IndexKindA(2)])
+    @test length(tgi.groups) == 2
+    (g1, p1), (g2, p2) = tgi.groups
+    @test g1 isa Vector{IndexKindA}
+    @test g1 == [IndexKindA(1), IndexKindA(2)]
+    @test p1 == [1, 3]
+    @test g2 isa Vector{IndexKindB}
+    @test g2 == [IndexKindB(1)]
+    @test p2 == [2]
+end
+
+struct TwoKindSys end
+SymbolicIndexingInterface.is_variable(::TwoKindSys, sym) = false
+SymbolicIndexingInterface.variable_index(::TwoKindSys, sym) = nothing
+SymbolicIndexingInterface.is_parameter(::TwoKindSys, sym) = sym in (:a, :b, :c)
+function SymbolicIndexingInterface.parameter_index(::TwoKindSys, sym)
+    if sym === :a
+        IndexKindA(1)
+    elseif sym === :b
+        IndexKindB(1)
+    elseif sym === :c
+        IndexKindB(2)
+    else
+        nothing
+    end
+end
+
+struct TwoKindParams{TA, TB, TC}
+    a::TA
+    b::TB
+    c::TC
+end
+
+struct TwoKindProb{P}
+    u0::Vector{Float64}
+    p::P
+end
+SymbolicIndexingInterface.state_values(prob::TwoKindProb) = prob.u0
+SymbolicIndexingInterface.parameter_values(prob::TwoKindProb) = prob.p
+
+function SymbolicIndexingInterface.remake_buffer(
+        ::TwoKindSys, oldbuf::TwoKindParams, idxs, vals)
+    # the contract under test: implementations must never receive an
+    # abstractly typed index collection
+    @test isconcretetype(eltype(idxs))
+    buf = oldbuf
+    for (idx, val) in zip(idxs, vals)
+        if idx isa IndexKindA
+            buf = TwoKindParams(val, buf.b, buf.c)
+        elseif idx == IndexKindB(1)
+            buf = TwoKindParams(buf.a, val, buf.c)
+        else
+            buf = TwoKindParams(buf.a, buf.b, val)
+        end
+    end
+    return buf
+end
+
+@testset "setp_oop groups mixed index types" begin
+    sys = TwoKindSys()
+    prob = TwoKindProb(Float64[], TwoKindParams(0.0, 0.0, 0.0))
+
+    set_mixed = setp_oop(sys, [:a, :b, :c])
+    @test set_mixed.idxs isa TypeGroupedIndexes
+    newps = set_mixed(prob, [1.0, 2.0, 3.0])
+    @test newps.a == 1.0
+    @test newps.b == 2.0
+    @test newps.c == 3.0
+    # value type changes flow through
+    newps2 = set_mixed(prob, [1, 2, 3])
+    @test newps2.a === 1
+    @test newps2.b === 2
+    @test newps2.c === 3
+
+    # homogeneous index types stay a plain concrete vector
+    set_homog = setp_oop(sys, [:b, :c])
+    @test set_homog.idxs isa Vector{IndexKindB}
+    newps3 = set_homog(prob, [5.0, 6.0])
+    @test newps3.b == 5.0
+    @test newps3.c == 6.0
+end
+
+@testset "setsym_oop groups mixed index types" begin
+    sys = TwoKindSys()
+    prob = TwoKindProb(Float64[], TwoKindParams(0.0, 0.0, 0.0))
+
+    setter = setsym_oop(sys, [:a, :b])
+    _, newps = setter(prob, [1.5, 2.5])
+    @test newps.a == 1.5
+    @test newps.b == 2.5
+end
+
+@testset "BatchedInterface setsym_oop groups mixed index types" begin
+    sys = TwoKindSys()
+    prob = TwoKindProb(Float64[], TwoKindParams(0.0, 0.0, 0.0))
+
+    bi = BatchedInterface((sys, [:a, :b]))
+    setter = setsym_oop(bi)
+    _, newps = setter(prob, 1, [1.5, 2.5])
+    @test newps.a == 1.5
+    @test newps.b == 2.5
+    ((_, newps2),) = setter(prob, [3.5, 4.5])
+    @test newps2.a == 3.5
+    @test newps2.b == 4.5
+end


### PR DESCRIPTION
## Problem

`setp_oop` / `setsym_oop` setters whose symbols span index types that differ in a type parameter — e.g. `Initial(v)` and a plain parameter in ModelingToolkit, whose `ParameterIndex{Portion, Int}` types differ in the portion — build an index vector whose eltype is the abstract typejoin (`ParameterIndex{P, Int64} where P`) and pass it to `remake_buffer` in a single call.

`MTKParameters`' `remake_buffer` computes per-portion buffer eltype promotion statically from `eltype(idxs)`; an abstract eltype matches none of its per-portion checks, so no buffer is promoted and setting non-`Float64` values throws:

```
MethodError: no method matching Float64(::ForwardDiff.Dual{...})
```

This breaks `ForwardDiff.gradient` over any solve-based loss that tunes an initial condition together with a parameter (parameter estimation with mixed u0/p search spaces). Homogeneous single-portion setters are unaffected.

Fixes SciML/ModelingToolkit.jl#4864 (see the issue for a solver-free MWE).

## What this does

- **`value_provider_interface.jl`**: adds `TypeGroupedIndexes`, which partitions an abstractly-typed index vector into concretely typed groups (first-occurrence order) together with each entry's position in the values collection. The `OOPSetter(indp, idxs, isstate)` constructor — the common construction point for all array-index OOP setters — applies it when `idxs isa AbstractVector && !isconcretetype(eltype(idxs))`. Specialized call methods then apply `remake_buffer` once per group (tuple recursion, unrolled).
- **`batched_interface.jl`**: the `setsym_oop(::BatchedInterface)` code generator emits the same chained per-group `remake_buffer` calls when an index vector's eltype is not concrete; concretely-typed vectors generate exactly the same code as before.

The grouping is index-provider-agnostic (partition by `typeof(idx)`, not by any portion concept), and providers with uniform index types (`SymbolCache` → `Int`) are unaffected.

### Why not splat into a `Tuple`?

Tuple indexes would also fix promotion (`fieldtypes` is concrete per element), but the generated `_remake_buffer` unrolls one `setindex!` per tuple element and respecializes per distinct index-set type — O(N) codegen for N-parameter search spaces, multiplied again under Enzyme. The group count here is bounded by the number of distinct index types (in practice 2), so codegen stays O(1) in the number of indexes; the cost is one extra buffer copy per additional group.

### Semantics

Relative order is preserved within each group. A symbol always maps to a single index type, so last-write-wins semantics for duplicate symbols are unchanged.

## Validation

- Full SII test suite passes; new regression test (`test/type_grouped_indexes_test.jl`) covers the partitioning, `setp_oop`, `setsym_oop`, and `BatchedInterface` routes with a two-index-type mock provider whose `remake_buffer` asserts it never receives an abstractly-typed index collection.
- The MWE from SciML/ModelingToolkit.jl#4864 passes with this change: mixed setters promote both portions to `Dual`, and `ForwardDiff.gradient` over a solve loss matches finite differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)