### PR TITLE
feat: allow indexing mixed timeseries vars if one of them is continuous

### DIFF
--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -142,7 +142,16 @@ end
 function (o::TimeDependentObservedFunction)(
         ::Timeseries, ::IndexerMixedTimeseries, prob, args...
     )
-    throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
+    if !(ContinuousTimeseries() in o.ts_idxs)
+        throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
+    end
+    mapfn = let inner = o.obsfn, indp = prob, valp = prob
+        function __mapfn(u, t)
+            cur_p = parameter_values_at_time(indp, valp, t)
+            return inner(u, cur_p, t)
+        end
+    end
+    return map(mapfn, state_values(prob), current_time(prob))
 end
 function (o::TimeDependentObservedFunction)(
         ::NotTimeseries, ::IndexerMixedTimeseries, prob, args...

--- a/src/state_indexing.jl
+++ b/src/state_indexing.jl
@@ -139,9 +139,7 @@ function (o::NonMarkovianObservedFunction)(::NotTimeseries, ::IndexerBoth, prob)
     )
 end
 
-function (o::TimeDependentObservedFunction)(
-        ::Timeseries, ::IndexerMixedTimeseries, prob, args...
-    )
+function (o::TimeDependentObservedFunction)(::Timeseries, ::IndexerMixedTimeseries, prob)
     if !(ContinuousTimeseries() in o.ts_idxs)
         throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
     end
@@ -152,6 +150,53 @@ function (o::TimeDependentObservedFunction)(
         end
     end
     return map(mapfn, state_values(prob), current_time(prob))
+end
+function (o::NonMarkovianObservedFunction)(::Timeseries, ::IndexerMixedTimeseries, prob)
+    if !(ContinuousTimeseries() in o.ts_idxs)
+        throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
+    end
+    mapfn = let inner = o.obsfn, indp = prob, valp = prob, h = get_history_function(prob)
+        function __mapfn(u, t)
+            cur_p = parameter_values_at_time(indp, valp, t)
+            return inner(u, h, cur_p, t)
+        end
+    end
+    return map(mapfn, state_values(prob), current_time(prob))
+end
+function (o::TimeDependentObservedFunction)(
+        ::Timeseries, ::IndexerMixedTimeseries, prob, i::Union{Int, CartesianIndex}
+    )
+    if !(ContinuousTimeseries() in o.ts_idxs)
+        throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
+    end
+    t = current_time(prob, i)
+    cur_p = parameter_values_at_time(prob, prob, t)
+    return o.obsfn(state_values(prob, i), cur_p, t)
+end
+function (o::NonMarkovianObservedFunction)(
+        ::Timeseries, ::IndexerMixedTimeseries, prob, i::Union{Int, CartesianIndex}
+    )
+    if !(ContinuousTimeseries() in o.ts_idxs)
+        throw(MixedParameterTimeseriesIndexError(prob, indexer_timeseries_index(o)))
+    end
+    t = current_time(prob, i)
+    cur_p = parameter_values_at_time(prob, prob, t)
+    return o.obsfn(state_values(prob, i), get_history_function(prob), cur_p, t)
+end
+function (o::TimeDependentObservedFunction)(
+        ts::Timeseries, ::IndexerMixedTimeseries, prob, ::Colon
+    )
+    return o(ts, prob)
+end
+function (o::TimeDependentObservedFunction)(
+        ts::Timeseries, ::IndexerMixedTimeseries, prob, i::AbstractArray{Bool}
+    )
+    return map(only(to_indices(current_time(prob), (i,)))) do idx
+        o(ts, prob, idx)
+    end
+end
+function (o::TimeDependentObservedFunction)(ts::Timeseries, ::IndexerMixedTimeseries, prob, i)
+    return o.((ts,), (prob,), i)
 end
 function (o::TimeDependentObservedFunction)(
         ::NotTimeseries, ::IndexerMixedTimeseries, prob, args...

--- a/test/parameter_indexing_test.jl
+++ b/test/parameter_indexing_test.jl
@@ -3,7 +3,7 @@ using SymbolicIndexingInterface: IndexerOnlyTimeseries, IndexerNotTimeseries, In
     IndexerMixedTimeseries,
     is_indexer_timeseries, indexer_timeseries_index,
     ParameterTimeseriesValueIndexMismatchError,
-    MixedParameterTimeseriesIndexError
+    MixedParameterTimeseriesIndexError, parameter_values_at_time
 using Test
 # AllocCheck uses LLVM introspection which can break on pre-release Julia versions
 @static if isempty(VERSION.prerelease)
@@ -555,18 +555,56 @@ temp_state = ProblemState(;
 _xval = temp_state.u[1]
 _bval = bval[1]
 _cval = cval[1]
+
+# These getters go through `MultipleGetters`, which always throws when mixing
+# timeseries indexes (state variables and parameter timeseries are always
+# considered separate indexes), regardless of whether one of them is the
+# continuous timeseries.
 for (sym, val, check_inference) in [
         ([:x, :b], [_xval, _bval], false),
         ((:x, :c), (_xval, _cval), true),
-        (:(x + b), _xval + _bval, true),
-        ([:(2b), :(3x)], [2_bval, 3_xval], true),
-        ((:(2b), :(3x)), (2_bval, 3_xval), true),
     ]
     getter = getsym(sys, sym)
     @test_throws MixedParameterTimeseriesIndexError getter(fs)
     for subidx in [1, CartesianIndex(2), :, rand(Bool, 4), rand(1:4, 3), 1:2]
         @test_throws MixedParameterTimeseriesIndexError getter(fs, subidx)
     end
+    if check_inference
+        @inferred getter(temp_state)
+    end
+    @test getter(temp_state) == val
+end
+
+# These getters go through `TimeDependentObservedFunction`, whose combined
+# timeseries indexes include `ContinuousTimeseries()` (since they involve `x`,
+# a continuous state variable). Indexing with such a getter on the full
+# timeseries object is now allowed, and evaluates the observed function at
+# the interpolated/held parameter timeseries values corresponding to each
+# point in the continuous timeseries.
+bval_at_t = [parameter_values_at_time(sys, fs, t)[2] for t in fs.t]
+for (sym, val, tsval, check_inference) in [
+        (:(x + b), _xval + _bval, xval .+ bval_at_t, true),
+        ([:(2b), :(3x)], [2_bval, 3_xval], vcat.(2 .* bval_at_t, 3 .* xval), true),
+        ((:(2b), :(3x)), (2_bval, 3_xval), tuple.(2 .* bval_at_t, 3 .* xval), true),
+    ]
+    getter = getsym(sys, sym)
+    if !(sym isa Tuple)
+        # `AsTupleWrapper` (used to wrap tuple-valued observed functions) does
+        # not itself implement `is_indexer_timeseries`.
+        @test is_indexer_timeseries(getter) == IndexerMixedTimeseries()
+    end
+    if check_inference
+        @inferred getter(fs)
+    end
+    @test getter(fs) == tsval
+    for subidx in [1, CartesianIndex(2), :, rand(Bool, length(tsval)), rand(eachindex(tsval), 3), 1:2]
+        if check_inference
+            @inferred getter(fs, subidx)
+        end
+        target = subidx isa Colon ? tsval : tsval[subidx]
+        @test getter(fs, subidx) == target
+    end
+
     if check_inference
         @inferred getter(temp_state)
     end

--- a/test/state_indexing_test.jl
+++ b/test/state_indexing_test.jl
@@ -1,5 +1,7 @@
 using SymbolicIndexingInterface
-using SymbolicIndexingInterface: NotVariableOrParameter
+using SymbolicIndexingInterface: NotVariableOrParameter, IndexerMixedTimeseries,
+    is_indexer_timeseries, MixedParameterTimeseriesIndexError, parameter_values_at_time,
+    TimeDependentObservedFunction
 # AllocCheck uses LLVM introspection which can break on pre-release Julia versions
 @static if isempty(VERSION.prerelease)
     using AllocCheck
@@ -491,4 +493,95 @@ SymbolicIndexingInterface.supports_tuple_observed(::TupleObservedWrapper) = true
     @test all(getter(ps) .≈ (0.3, 0.5))
     @test getter(ps) isa Tuple
     @test_nowarn @inferred getter(ps)
+end
+
+struct MixedTSDiffEqArray
+    t::Vector{Float64}
+    u::Vector{Vector{Float64}}
+end
+SymbolicIndexingInterface.current_time(mda::MixedTSDiffEqArray) = mda.t
+SymbolicIndexingInterface.state_values(mda::MixedTSDiffEqArray) = mda.u
+SymbolicIndexingInterface.is_timeseries(::Type{MixedTSDiffEqArray}) = Timeseries()
+
+struct MixedTSParameterObject
+    p::Vector{Float64}
+end
+SymbolicIndexingInterface.parameter_values(mpo::MixedTSParameterObject) = mpo.p
+function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
+        ::SymbolCache, mpo::MixedTSParameterObject, args::Pair...
+    )
+    for (ts_idx, val) in args
+        mpo.p[1 + ts_idx] = only(val)
+    end
+    return mpo
+end
+Base.getindex(mpo::MixedTSParameterObject, i) = mpo.p[i]
+
+# A timeseries solution object with both continuous states and a parameter
+# timeseries, used to test indexing observed variables that mix the two.
+struct MixedTSSolution{S}
+    sys::S
+    u::Vector{Vector{Float64}}
+    t::Vector{Float64}
+    p::MixedTSParameterObject
+    p_ts::ParameterTimeseriesCollection
+end
+SymbolicIndexingInterface.state_values(fs::MixedTSSolution) = fs.u
+SymbolicIndexingInterface.current_time(fs::MixedTSSolution) = fs.t
+SymbolicIndexingInterface.symbolic_container(fs::MixedTSSolution) = fs.sys
+SymbolicIndexingInterface.parameter_values(fs::MixedTSSolution) = fs.p
+SymbolicIndexingInterface.parameter_values(fs::MixedTSSolution, i) = fs.p[i]
+SymbolicIndexingInterface.get_parameter_timeseries_collection(fs::MixedTSSolution) = fs.p_ts
+SymbolicIndexingInterface.is_timeseries(::Type{<:MixedTSSolution}) = Timeseries()
+SymbolicIndexingInterface.is_parameter_timeseries(::Type{<:MixedTSSolution}) = Timeseries()
+SymbolicIndexingInterface.get_history_function(fs::MixedTSSolution) = t -> t .* ones(3)
+
+@testset "Indexing mixed timeseries vars when one is continuous" begin
+    sc = SymbolCache(
+        [:x, :y, :z], [:a, :b], :t;
+        timeseries_parameters = Dict(:b => ParameterTimeseriesIndex(1, 1))
+    )
+    b_ts = MixedTSDiffEqArray(collect(0.0:0.1:0.9), [[2.5i] for i in 1:10])
+    p0 = MixedTSParameterObject([20.0, b_ts.u[end][1]])
+
+    for sys in [sc, NonMarkovianWrapper(sc)]
+        markovian = sys === sc
+        u = [i * ones(3) for i in 1:5]
+        t = [0.2i for i in 1:5]
+        ptc = ParameterTimeseriesCollection([deepcopy(b_ts)], deepcopy(p0))
+        fs = MixedTSSolution(sys, u, t, deepcopy(p0), ptc)
+
+        xval = getindex.(fs.u, 1)
+        bval_at_t = [parameter_values_at_time(sys, fs, ti)[2] for ti in fs.t]
+        # `NonMarkovianWrapper`'s observed function adds `h(t - 0.1)` to the
+        # state before calling the underlying observed function.
+        hval_at_t = markovian ? zeros(length(fs.t)) : [ti - 0.1 for ti in fs.t]
+        expected = xval .+ hval_at_t .+ bval_at_t
+
+        getter = getsym(sys, :(x + b))
+        @test is_indexer_timeseries(getter) == IndexerMixedTimeseries()
+        @test getter(fs) ≈ expected
+        for subidx in [
+                1, CartesianIndex(2), :, rand(Bool, length(fs.t)),
+                rand(eachindex(fs.t), 3), 1:3,
+            ]
+            target = subidx isa Colon ? expected : expected[subidx]
+            @test getter(fs, subidx) ≈ target
+        end
+    end
+
+    # A `TimeDependentObservedFunction` is only ever constructed by `getsym`
+    # when its combined timeseries indexes include `ContinuousTimeseries()`
+    # (that's the only case where it makes sense to hold parameter timeseries
+    # values fixed while iterating over the continuous timeseries). Directly
+    # constructing one without `ContinuousTimeseries()` in `ts_idxs` should
+    # still throw, since there is no continuous timeseries to iterate over.
+    o = TimeDependentObservedFunction{true}([1, 2], (u, p, t) -> u[1] + p[2])
+    b_ts = MixedTSDiffEqArray(collect(0.0:0.1:0.9), [[2.5i] for i in 1:10])
+    p0 = MixedTSParameterObject([20.0, b_ts.u[end][1]])
+    fs = MixedTSSolution(
+        sc, [i * ones(3) for i in 1:5], [0.2i for i in 1:5], deepcopy(p0),
+        ParameterTimeseriesCollection([deepcopy(b_ts)], deepcopy(p0))
+    )
+    @test_throws MixedParameterTimeseriesIndexError o(Timeseries(), fs)
 end


### PR DESCRIPTION
This allows continuous variables depending on discrete ones to be indexed easily. The reasoning is that if it depends on continuous and discrete partitions, it is a continuously varying quantity with some point discontinuities (or derivative discontinuities) and should be indexed as continuous variables