### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
@@ -22,6 +23,7 @@ Aqua = "0.8"
 ArrayInterface = "7.26"
 JET = "0.9, 0.10, 0.11"
 PrettyTables = "3"
+PrecompileTools = "1.2.1"
 RuntimeGeneratedFunctions = "0.5.21"
 SafeTestsets = "0.1"
 SciMLTesting = "2.4"

--- a/src/SymbolicIndexingInterface.jl
+++ b/src/SymbolicIndexingInterface.jl
@@ -1,6 +1,7 @@
 module SymbolicIndexingInterface
 
 using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFunction
+using PrecompileTools: @compile_workload, @setup_workload
 import StaticArraysCore: MArray, similar_type
 import ArrayInterface
 using Accessors: @reset
@@ -51,5 +52,6 @@ export remake_buffer
 include("remake.jl")
 
 include("despecialize.jl")
+include("precompilation.jl")
 
 end

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,20 @@
+@setup_workload begin
+    indp = SymbolCache([:x, :y], [:a, :b], :t)
+    valp = ProblemState(; u = [1.0, 2.0], p = [3.0, 4.0], t = 0.5)
+    state_getter = getsym(indp, [:x, :y])
+    parameter_getter = getp(indp, [:a, :b])
+    state_setter = setsym(indp, [:x, :y])
+    parameter_setter = setp(indp, [:a, :b])
+
+    @compile_workload begin
+        SymbolCache([:x, :y], [:a, :b], :t)
+        ProblemState(; u = [1.0, 2.0], p = [3.0, 4.0], t = 0.5)
+        getsym(indp, :x)(valp)
+        state_getter(valp)
+        parameter_getter(valp)
+        state_buffer = zeros(2)
+        state_getter(state_buffer, valp)
+        state_setter(valp, [5.0, 6.0])
+        parameter_setter(valp, [7.0, 8.0])
+    end
+end

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,20 +1,10 @@
 @setup_workload begin
     indp = SymbolCache([:x, :y], [:a, :b], :t)
     valp = ProblemState(; u = [1.0, 2.0], p = [3.0, 4.0], t = 0.5)
-    state_getter = getsym(indp, [:x, :y])
-    parameter_getter = getp(indp, [:a, :b])
-    state_setter = setsym(indp, [:x, :y])
-    parameter_setter = setp(indp, [:a, :b])
 
     @compile_workload begin
-        SymbolCache([:x, :y], [:a, :b], :t)
-        ProblemState(; u = [1.0, 2.0], p = [3.0, 4.0], t = 0.5)
-        getsym(indp, :x)(valp)
-        state_getter(valp)
-        parameter_getter(valp)
-        state_buffer = zeros(2)
-        state_getter(state_buffer, valp)
-        state_setter(valp, [5.0, 6.0])
-        parameter_setter(valp, [7.0, 8.0])
+        variable_symbols(indp)
+        state_values(valp)
+        parameter_values(valp)
     end
 end

--- a/test/precompile_workload.jl
+++ b/test/precompile_workload.jl
@@ -1,0 +1,21 @@
+using SymbolicIndexingInterface
+using Test
+
+indp = SymbolCache([:x, :y], [:a, :b], :t)
+valp = ProblemState(; u = [1.0, 2.0], p = [3.0, 4.0], t = 0.5)
+
+@test getsym(indp, :x)(valp) == 1.0
+@test getsym(indp, :(x + a + t))(valp) == 4.5
+@test getp(indp, [:a, :b])(valp) == [3.0, 4.0]
+
+state_setter = setsym(indp, [:x, :y])
+state_setter(valp, [5.0, 6.0])
+@test state_values(valp) == [5.0, 6.0]
+
+parameter_setter = setp(indp, [:a, :b])
+parameter_setter(valp, [7.0, 8.0])
+@test parameter_values(valp) == [7.0, 8.0]
+
+batch = BatchedInterface((indp, [:x, :a]), (indp, [:y, :b]))
+@test variable_symbols(batch) == [:x, :a, :y, :b]
+@test getsym(batch)(valp, valp) == [5.0, 7.0, 6.0, 8.0]


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.