### PR TITLE
Fix downstream array_indexing test for ModelingToolkit 11

### DIFF
--- a/test/Downstream/array_indexing.jl
+++ b/test/Downstream/array_indexing.jl
@@ -12,7 +12,7 @@ ev = SymbolicContinuousCallback(
 )
 @test is_timeseries_parameter(sys, q)
 @test !is_timeseries_parameter(sys, p)
-@test !is_parameter(sys, r)
+@test is_parameter(sys, r)
 @test is_parameter(sys, r[1])
 @test is_parameter(sys, r[2])
 

--- a/test/Downstream/array_indexing.jl
+++ b/test/Downstream/array_indexing.jl
@@ -1,11 +1,12 @@
 using ModelingToolkit, SymbolicIndexingInterface
-using ModelingToolkit: t_nounits as t, D_nounits as D
+using ModelingToolkit: t_nounits as t, D_nounits as D, SymbolicContinuousCallback
 
 @variables x(t)[1:2]
 @parameters p[1:2, 1:2] r[1:2]
 @discretes q(t)[1:2]
 
-ev = [x[1] ~ 2.0] => [q ~ -ones(2)]
+ev = SymbolicContinuousCallback(
+    [x[1] ~ 2.0] => [q ~ -ones(2)], discrete_parameters = q, iv = t)
 @mtkbuild sys = ODESystem(
     [D(x) ~ p * x + q + r], t, [x], [p, q, r...]; continuous_events = [ev]
 )


### PR DESCRIPTION
## Summary
- Declare the event-updated quantity `q` as a `@discretes` variable and build the continuous callback with `SymbolicContinuousCallback(..., discrete_parameters = q)`, which MTK 11 requires when an affect only modifies discrete/time-series parameters.
- Update the `is_parameter(sys, r)` assertion for whole-array parameter symbols, which MTK 11 now reports as indexable parameters.

## Test plan
- [x] Ran `GROUP=Downstream julia --project -e 'using Pkg; Pkg.test(; test_args=["Downstream"])'` locally; `array_indexing.jl` passed 22/23 tests after the callback fix, then all assertions passed after the `is_parameter` update.