### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,64 @@
+using SymbolicIndexingInterface, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+sys = SymbolCache(
+    [:x, :y, :z], [:a, :b], :t;
+    defaults = Dict(:x => 1, :y => :(2b), :b => :(2a + x))
+)
+sys_plain = SymbolCache([:x, :y, :z], [:a, :b], :t)
+
+u = ones(3)
+p = 2ones(2)
+t = 3.0
+
+# =============================================================================
+# SymbolCache
+# =============================================================================
+
+SUITE["symbol_cache"] = BenchmarkGroup()
+SUITE["symbol_cache"]["construct"] = @benchmarkable SymbolCache(
+    [:x, :y, :z], [:a, :b], :t
+)
+SUITE["symbol_cache"]["construct_defaults"] = @benchmarkable SymbolCache(
+    [:x, :y, :z], [:a, :b], :t;
+    defaults = Dict(:x => 1, :y => :(2b), :b => :(2a + x))
+)
+SUITE["symbol_cache"]["variable_symbols"] = @benchmarkable variable_symbols($sys)
+SUITE["symbol_cache"]["variable_index"] = @benchmarkable variable_index($sys, :y)
+SUITE["symbol_cache"]["symbolic_evaluate"] = @benchmarkable symbolic_evaluate(
+    :(x + y), merge(default_values($sys), Dict(:a => 2))
+)
+
+# =============================================================================
+# observed / parameter_observed function generation and evaluation
+# =============================================================================
+
+SUITE["observed"] = BenchmarkGroup()
+
+SUITE["observed"]["create"] = @benchmarkable observed($sys_plain, :(x + a + t))
+SUITE["observed"]["create_vector"] = @benchmarkable observed(
+    $sys_plain, [:(x + a), :(a + t)]
+)
+
+obsfn = observed(sys_plain, :(x + a + t))
+obsfn_vec = observed(sys_plain, [:(x + a), :(a + t)])
+pobsfn = parameter_observed(sys_plain, :(a + b + t))
+
+SUITE["observed"]["eval"] = @benchmarkable $obsfn($u, $p, $t)
+SUITE["observed"]["eval_vector"] = @benchmarkable $obsfn_vec($u, $p, $t)
+SUITE["observed"]["parameter_eval"] = @benchmarkable $pobsfn($p, $t)
+
+# =============================================================================
+# remake_buffer
+# =============================================================================
+
+SUITE["remake_buffer"] = BenchmarkGroup()
+
+buf = [1.0, 2.0, 3.0]
+SUITE["remake_buffer"]["vector"] = @benchmarkable remake_buffer(
+    $sys_plain, $buf, [:x, :y], [2.0, 3.0]
+)
+SUITE["remake_buffer"]["params"] = @benchmarkable remake_buffer(
+    $sys_plain, $buf, [:a, :b], [2.0, 3.0]
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~10s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~10s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md