### PR TITLE
Format array_indexing.jl with Runic

### DIFF
--- a/test/Downstream/array_indexing.jl
+++ b/test/Downstream/array_indexing.jl
@@ -6,7 +6,8 @@ using ModelingToolkit: t_nounits as t, D_nounits as D, SymbolicContinuousCallbac
 @discretes q(t)[1:2]
 
 ev = SymbolicContinuousCallback(
-    [x[1] ~ 2.0] => [q ~ -ones(2)], discrete_parameters = q, iv = t)
+    [x[1] ~ 2.0] => [q ~ -ones(2)], discrete_parameters = q, iv = t
+)
 @mtkbuild sys = ODESystem(
     [D(x) ~ p * x + q + r], t, [x], [p, q, r...]; continuous_events = [ev]
 )


### PR DESCRIPTION
## Summary

`format-check` on master fails on `test/Downstream/array_indexing.jl` — the `SymbolicContinuousCallback` call needs its closing paren on its own line per current Runic rules. This applies `Runic.format_file` to that file; no other files are flagged.

## Test plan

- [x] Local `Runic.format_file` produces exactly the diff CI's format check reports

🤖 Generated with [Devin](https://devin.ai) — Agent-Harness: Devin CLI 3000.10.21, Agent-Model: SWE-2 Max, Agent-Session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md (local session transcript; no shareable URL)